### PR TITLE
Fix crash and improved usabiliy

### DIFF
--- a/ddg/central_widget.py
+++ b/ddg/central_widget.py
@@ -51,13 +51,27 @@ class CentralWidget(QtWidgets.QDialog, CLASS_DIALOG):
         self.findChild(QtWidgets.QFrame, 'framePointWidget').layout().addWidget(self.point_widget)
         self.point_widget.hide_custom_fields.connect(self.hide_custom_fields)
 
+        self.save_shortcut = QtWidgets.QShortcut(QtGui.QKeySequence(self.tr("Ctrl+S")), self)  # quick save using Ctrl+S
+        self.save_shortcut.setContext(QtCore.Qt.WidgetWithChildrenShortcut)
+        self.save_shortcut.activated.connect(self.point_widget.quick_save)
+
         self.up_arrow = QtWidgets.QShortcut(QtGui.QKeySequence(QtCore.Qt.Key_Up), self)
         self.up_arrow.setContext(QtCore.Qt.WidgetWithChildrenShortcut)
         self.up_arrow.activated.connect(self.point_widget.previous)
-
+        
         self.down_arrow = QtWidgets.QShortcut(QtGui.QKeySequence(QtCore.Qt.Key_Down), self)
         self.down_arrow.setContext(QtCore.Qt.WidgetWithChildrenShortcut)
         self.down_arrow.activated.connect(self.point_widget.next)
+
+        # same as arrows but conventient for right handed people
+        self.up_arrow = QtWidgets.QShortcut(QtGui.QKeySequence(self.tr("W")), self)
+        self.up_arrow.setContext(QtCore.Qt.WidgetWithChildrenShortcut)
+        self.up_arrow.activated.connect(self.point_widget.previous)
+        
+        self.down_arrow = QtWidgets.QShortcut(QtGui.QKeySequence(self.tr("S")), self)
+        self.down_arrow.setContext(QtCore.Qt.WidgetWithChildrenShortcut)
+        self.down_arrow.activated.connect(self.point_widget.next)
+
 
         self.graphicsView.setScene(self.canvas)
         self.graphicsView.drop_complete.connect(self.canvas.load)


### PR DESCRIPTION
1. The crash arouse in MacOS, where in some edge cases app crashed due:
![Screen Shot 2020-05-24 at 14 24 16](https://user-images.githubusercontent.com/15726543/82754721-9154ba80-9dd7-11ea-913f-06d0c3b879bc.png)

(for some reason the `item.text()` returns '')

2. Change the resize behaviour of the Image column as it trims the end of the image name (which is usually the unique part that separates from 2 consecutive images).
If you have better solution of letting the count just a minimal width i'd glad to enhance the behaviour

3. Added quick save option (using Ctrl + S) to override the same .pnt file that was loaded in the beginning / the last one it was saved. Old saved mechanism untocuhed

4. Added 'W', 'S' as alternative keys for Up/Down arrows when navigating through images (wanted to use Command key + S / Command key + W but wasn't sure if it might cause issues with Windows users, will be glad for your input)

Thanks 