### PR TITLE
fix export error when some custom fields empty

### DIFF
--- a/ddg/canvas.py
+++ b/ddg/canvas.py
@@ -169,7 +169,7 @@ class Canvas(QtWidgets.QGraphicsScene):
                     if image in self.custom_fields['data'][field_name]:
                         output += ',{}'.format(self.custom_fields['data'][field_name][image])
                     else:
-                        output == ','
+                        output += ','
                 output += "\n"
                 file.write(output)
             file.close()


### PR DESCRIPTION
Issue is when exporting points to csv, the typo causes ignoring of non existing fields